### PR TITLE
Make sure all grammars get recognized

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,7 @@
 module.exports =
   # Activates the package.
   activate: ->
+    atom.syntax.getGrammars().map (grammar) -> createCommand(grammar)
     atom.syntax.on 'grammar-added', (grammar) -> createCommand(grammar)
 
 # Creates the command for a given {Grammar}.


### PR DESCRIPTION
Most of the time atom was missing crucial grammars like `coffeescript` or `javascript` for me. I suspect they we're loaded _before_ set-syntax got activiated.

This is fixed by adding already active grammars to the list.
