### PR TITLE
Add disposable only if a command is actually created

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,10 +6,10 @@ module.exports =
     @disposables = new CompositeDisposable
 
     atom.grammars.getGrammars().map (grammar) =>
-      @disposables.add @createCommand(grammar)
+      @createCommand(grammar)
 
     @disposables.add atom.grammars.onDidAddGrammar (grammar) =>
-      @disposables.add @createCommand(grammar)
+      @createCommand(grammar)
 
   # Public: Deactivates the package.
   deactivate: ->
@@ -21,5 +21,5 @@ module.exports =
   createCommand: (grammar) ->
     if grammar?.name?
       workspaceElement = atom.views.getView(atom.workspace)
-      atom.commands.add workspaceElement, "set-syntax:#{grammar.name}", ->
+      @disposables.add atom.commands.add workspaceElement, "set-syntax:#{grammar.name}", ->
         atom.workspace.getActiveTextEditor()?.setGrammar(grammar)


### PR DESCRIPTION
`CompositeDisposable` still has problems when `undefined` is added to it. This prevents `undefined` from being added as a Disposable and should prevent strange exceptions.

Fixes #11 
